### PR TITLE
implement Default for vector and matrices

### DIFF
--- a/src/mat.rs
+++ b/src/mat.rs
@@ -124,6 +124,12 @@ macro_rules! mat_impl {
             }
         }
 
+        impl<T> Default for $MatN<T> where T: Number {
+            fn default() -> Self {
+                Self::zero()
+            }
+        }
+
         impl<T> Eq for $MatN<T> where T: Eq  {}
         impl<T> PartialEq for $MatN<T> where T: PartialEq  {
             fn eq(&self, other: &Self) -> bool {

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -126,7 +126,7 @@ macro_rules! mat_impl {
 
         impl<T> Default for $MatN<T> where T: Number {
             fn default() -> Self {
-                Self::zero()
+                Self::identity()
             }
         }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -867,6 +867,12 @@ macro_rules! vec_impl {
             }
         }
 
+        impl<T> Default for $VecN<T> where T: Number {
+            fn default() -> Self {
+                Self::zero()
+            }
+        }
+
         //
         // ops
         //

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -924,10 +924,7 @@ fn matrix_get_rows_columns() {
 #[test]
 fn matrix_default() {
     let m4 : Mat4<f32> = Default::default();
-    for i in 0..4 {
-        assert_eq!(m4.get_row(i), vec4f(0.0, 0.0, 0.0, 0.0));
-        assert_eq!(m4.get_column(i), vec4f(0.0, 0.0, 0.0, 0.0));
-    }
+    assert_eq!(m4, Mat4f::identity());
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -652,6 +652,13 @@ fn perp_product() {
 }
 
 #[test]
+fn default() {
+    let vz : Vec3f = Default::default();
+    let expected = vec3f(0.0, 0.0, 0.0);
+    assert_eq!(vz, expected);
+}
+
+#[test]
 fn zero() {
     let vz = Vec3f::zero();
     let expected = vec3f(0.0, 0.0, 0.0);
@@ -912,6 +919,15 @@ fn matrix_get_rows_columns() {
     };
     assert_eq!(m34.get_row(1), vec4f(4.0, 5.0, 6.0, 7.0));
     assert_eq!(m34.get_column(2), vec3f(2.0, 6.0, 10.0));
+}
+
+#[test]
+fn matrix_default() {
+    let m4 : Mat4<f32> = Default::default();
+    for i in 0..4 {
+        assert_eq!(m4.get_row(i), vec4f(0.0, 0.0, 0.0, 0.0));
+        assert_eq!(m4.get_column(i), vec4f(0.0, 0.0, 0.0, 0.0));
+    }
 }
 
 #[test]


### PR DESCRIPTION
We're using maths-rs for vector types in http://oort.rs. It would be nice if these types could be used with `derive(Default)`.